### PR TITLE
fix filename typo, add readme instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ cd
 pip3 install selenium
 pip3 install requests
 ```
+or
+```elm
+pip3 install -r requirements.txt
+```
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+selenium
+requests


### PR DESCRIPTION
requirements.txt contained a type in the filename. Also added instructions for requirements installation (via requirements.txt) to README.md